### PR TITLE
Using NVM to install NodeJS and NPM

### DIFF
--- a/DockerFile
+++ b/DockerFile
@@ -35,7 +35,7 @@ ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 6.3.0
 
 # NVM && NODE INSTALL
-RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.20.0/install.sh | bash \
+RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash \
     && source $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \

--- a/DockerFile
+++ b/DockerFile
@@ -31,10 +31,17 @@ RUN echo 'source /usr/local/rvm/scripts/rvm' >> /etc/bash.bashrc
 # GIT INSTALL
 RUN apt-get install -y  git
 
-# NODE INSTALL
-RUN apt-get install -y nodejs
-RUN apt-get install -y build-essential
-RUN apt-get install -y npm
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 6.3.0
+
+# NVM && NODE INSTALL
+RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.20.0/install.sh | bash \
+    && source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 RUN echo 'nodejs --version' >> /etc/bash.bashrc
 
 # PhantomJS Install

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The container is based on Linux Ubuntu 14.04 and has:
   - RVM (Ruby Version Manager)
   - Ruby 2.3.0
   - Rails latest version
-  - NodeJS
+  - NVM (NodeJS Version Manager)
+  - NodeJS 6.3.0
   - NGINX server
   - GIT
   - PhantomJS 2.2.1

--- a/nvm_start.sh
+++ b/nvm_start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -f /.nvm_started ]; then
+    nvm --version && node --version
+    exit 0
+fi
+
+echo "NVM && NODE OK"
+source /usr/local/nvm
+nvm --version && node --version
+touch /.nvm_started


### PR DESCRIPTION
NVM is much easier to mantain than Ubuntu's vanilla NodeJS.
https://github.com/creationix/nvm